### PR TITLE
Fix popup status message visibility

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -278,12 +278,19 @@ class PopupController {
   }
 
   showMessage(text, type = "info") {
+    // Ensure the message is visible each time it's shown
+    if (this.messageTimeout) {
+      clearTimeout(this.messageTimeout);
+    }
+
     this.elements.statusMessage.textContent = text;
     this.elements.statusMessage.className = `status-message ${type}`;
+    this.elements.statusMessage.style.display = "block";
 
     // Auto-hide after 5 seconds
-    setTimeout(() => {
+    this.messageTimeout = setTimeout(() => {
       this.elements.statusMessage.style.display = "none";
+      this.messageTimeout = null;
     }, 5000);
   }
 }


### PR DESCRIPTION
## Summary
- ensure popup message box always shows when calling `showMessage`
- clear old hide timers to prevent race conditions

## Testing
- `node -c background.js`
- `node -c scraper.js`
- `node -c popup/popup.js`

------
https://chatgpt.com/codex/tasks/task_e_68635e443858832f9719cf8155180fd8